### PR TITLE
Fix to database create

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ To get there go to "Containers" and click on your container.<br/>
 ![image](https://github.com/ITU-BDSA23-GROUP4/Chirp/assets/143702901/797cb7e5-e011-4afc-8d0b-3aa77a429983)<br/>
 Her you can run bash commands on your container and look around the container.<br/>
 We are here to use the MsSQL tool to make a database on this container. To do this we run this ```/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Admin123``` (the ```-U``` is the user in our case we will just use SA which is System Admin and ```-P``` is the password for SA) this will gain access to the MsSQL tool. Here we can run SQL commands. Bare in mind that this is a diffrent tool the usual and have different commands.<br/>
-The commands we will run is to make the database that we will be using.<br/>
-1. ```/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Admin123```
-2. ```CREATE DATABASE chirpdb;```
-3. ```GO```
-This will create the database. This means you can also do queries here if you want to look into the database if you get out of the MsSQL tool you can get back with ```/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P Admin123``` and if you want to leave use ```QUIT```.
 ## What is that command
 In this section i will give a brief rundown of what is going on in the command. <br />
 ```docker run``` Is something i believe you know since this is what starts the command. <br />

--- a/src/Chirp.Razor/Program.cs
+++ b/src/Chirp.Razor/Program.cs
@@ -25,6 +25,7 @@ stringBuilder.InitialCatalog = "bdsagroup4-chirpdb";
 
 if (builder.Environment.IsDevelopment())
 {
+    Console.WriteLine("Development environment detected");
     builder.Services.AddDbContext<ChirpDBContext>(options =>
     {
         options.UseSqlServer(builder.Configuration.GetConnectionString("ChirpDB"));
@@ -56,10 +57,15 @@ using var scope = app.Services.CreateScope();
 var services = scope.ServiceProvider;
 var dbContext = services.GetRequiredService<ChirpDBContext>();
 
-if (dbContext.Database.EnsureDeleted())
+
+
+// Check if database exists and create it if it doesn't exist if run in development mode
+if (builder.Environment.IsDevelopment())
 {
-    dbContext.Database.Migrate();
-    DbInitializer.SeedDatabase(dbContext);
+    if (dbContext.Database.EnsureCreated())
+    {
+        DbInitializer.SeedDatabase(dbContext);
+    }
 }
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
I have now made it so the database will only be created if the database does not exist on your docker. This part of the code will not be used on Azure since the SQL Server should not need to be remade every time it's published.