### PR TITLE
Fixed bug

### DIFF
--- a/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
@@ -71,6 +71,7 @@ public class UserTimelineModel : PageModel
             else if (unfollow != null) 
             {
                 await _service.RemoveFollowee(currentUser.Name, unfollow);
+                return Redirect(User.Identity.Name);
             }
         } 
 


### PR DESCRIPTION
If a user unfollowed someone from their own timeline it wouldn't update the page and still show the unfollowed persons cheeps but the dynamic buttons would correctly only show cheeps for the others