### PR TITLE
Fixed bug not showing correct number of pages on a usertimeline

### DIFF
--- a/Docs/RunTestLocally.md
+++ b/Docs/RunTestLocally.md
@@ -58,11 +58,11 @@ if you run in to issues with the version of .net replace net7.0 in the command w
 if you don't have powerShell installed follow these instructions
 [Install PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.4)
 
-Extra logic for authorization hasn't been implemented so the developer has to manually enter their Github username into the variable at line 18 in the **PlaywrightTests.cs** file. Further explanation is also found there. After completing these steps you can run the test with: 
+After completing these steps you can run the test with: 
 ```bash 
 dotnet test 
   ```
-When you run the test a chromium based browser will open and the first step tries to login. Here the automation stops and the user has to log in through Github themselves. **No passwords are saved!** After this step is completed playwright will do the rest itself.
+When you run the test a chromium based browser will open and the first step tries to log in. Here the automation stops and the user has to log in through Github themselves. **No passwords are saved!** After this step is completed playwright will do the rest itself.
 
 ### what is tested
 The playwright test differs from the razor test in that it, mimics user behavior on our live website compared to the razor test which test locally. The test navigates through different pages and interacts with the website's functionality confirming that what it interacts with is as expected in the test. 

--- a/src/Chirp.Infrastructure/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/CheepRepository.cs
@@ -304,6 +304,7 @@ public class CheepRepository : ICheepRepository
         //OrderByDescending doesn't sort the list but returns a new sequence, therefore we need to assign it to a new list
         var sortedCheeps = cheepsToReturn.OrderByDescending(a => a.Timestamp.Ticks).ToList();
         int? page = (pageNum - 1) * 32;
+        Console.WriteLine("So many cheeps to print wow: " + cheepsToReturn.Count  + "\n \n\n\n\n\n\n\n\n");
         
         if (cheepsToReturn.Count < 32)
         {

--- a/src/Chirp.Infrastructure/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/CheepRepository.cs
@@ -304,7 +304,6 @@ public class CheepRepository : ICheepRepository
         //OrderByDescending doesn't sort the list but returns a new sequence, therefore we need to assign it to a new list
         var sortedCheeps = cheepsToReturn.OrderByDescending(a => a.Timestamp.Ticks).ToList();
         int? page = (pageNum - 1) * 32;
-        Console.WriteLine("So many cheeps to print wow: " + cheepsToReturn.Count  + "\n \n\n\n\n\n\n\n\n");
         
         if (cheepsToReturn.Count < 32)
         {

--- a/src/Chirp.Razor/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Razor/Pages/UserTimeline.cshtml
@@ -63,7 +63,7 @@
                         </li>
                     }
                 </ul>
-                @if(User?.Identity?.Name!=null){
+                @if(User?.Identity?.Name!=null && User.Identity.Name == Model.Author){
                  <div class="pageNumber">
                     <span>Page:</span>
                     
@@ -72,15 +72,22 @@
                         <button onclick="location.href='?page=@i'">@i</button>
                     }
                 </div>
-                <div class="pageNumber">
-                    <button onclick="location.href='?page=1'">Go to page 1</button>
-                </div>
                 }
+               @if(User?.Identity?.Name!=null && Model.Cheeps.Count!=0 && User.Identity.Name != Model.Author)
+               {
+                @for (int i = 1; i < ((Model._service.GetCountOfAllCheepFromAuthor(Model.Author)/32)+2); i++)
+                    {   
+                        <button onclick="location.href='?page=@i'">@i</button>
+                    }
+               }
             }
             else
             {
                 <em>There are no cheeps so far.</em>
             }
+            <div class="pageNumber">
+                    <button onclick="location.href='?page=1'">Go to page 1</button>
+            </div>
         }
     }
 </div>

--- a/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
@@ -47,7 +47,7 @@ public class UserTimelineModel : PageModel
                 Cheeps = _service.CombineCheepsAndFollowerCheeps(author ,pageNum);
                 
             } else {
-                Cheeps = _service.GetCheepsFromAuthor(author, pageNum);
+                Cheeps = _service.CombineCheepsAndFollowerCheeps(author, pageNum);
             }
         }
         // the else statement with the same code ensures page 0 and page 1 shows the same cheeps
@@ -58,7 +58,7 @@ public class UserTimelineModel : PageModel
                 Cheeps =  _service.CombineCheepsAndFollowerCheeps(author ,pageNum);
                 
             } else {
-                Cheeps = _service.GetCheepsFromAuthor(author, pageNum);
+                Cheeps = _service.CombineCheepsAndFollowerCheeps(author, pageNum);
             }
         }
 

--- a/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Razor/Pages/UserTimeline.cshtml.cs
@@ -37,6 +37,9 @@ public class UserTimelineModel : PageModel
 
     [FromQuery(Name ="unfollow")]
     public string? unfollow{ get; set; }
+    
+    [BindProperty(SupportsGet = true)]
+    public string Author { get; set; }
 
     public async Task<ActionResult> OnGet(string author)
     {

--- a/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
+++ b/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
@@ -13,12 +13,11 @@ class Program
     for now the developer has to manually login when running the test. Simply run dotnet run, and
     a private firefox window will open and playwright will direct the developer to login wherein you
     enter your credentials and the test will run as normal. your credentials are NOT SAVED anywhere
-    insert your github username into the variable at line 21*/
+   */
 
     [Test]
     public static async Task Main()
     {
-        string username = "YourGithubUsername";
         using var playwright = await Playwright.CreateAsync();
         await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
         {
@@ -30,61 +29,63 @@ class Program
 
         await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/");
 
+        await page.GetByRole(AriaRole.Button, new() { Name = "1", Exact = true }).ClickAsync();
+
+        await page.GetByRole(AriaRole.Button, new() { Name = "2", Exact = true }).ClickAsync();
+
         await page.GetByRole(AriaRole.Link, new() { Name = "Icon1Chirp!" }).ClickAsync();
-
-        await page.Locator("div").Filter(new() { HasText = "public timeline | login |" }).Nth(1).ClickAsync();
-
-        await page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
-
-        await page.Locator("div").Filter(new() { HasText = "my timeline | public timeline" }).Nth(1).ClickAsync();
-
-        await page.GetByRole(AriaRole.Link, new() { Name = "my timeline" }).ClickAsync();
-
-        await page.Locator("form").ClickAsync();
-
-        await page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
 
         await page.GetByRole(AriaRole.Heading, new() { Name = "Public Timeline" }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Button, new() { Name = "1", Exact = true }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = "2", Exact = true }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Button, new() { Name = "21" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Button, new() { Name = "20" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "login" }).ClickAsync();
 
-        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/Helge");
+        await page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
 
-        await page.GetByText("Helge Hello, BDSA students").ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "my timeline" }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Helge's Timeline" }).ClickAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = "Share" }).ClickAsync();
 
-        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/Rasmus");
-
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Rasmus's Timeline" }).ClickAsync();
-
-        await page.GetByText("Rasmus Hej, velkommen til").ClickAsync();
+        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/");
 
         await page.GetByRole(AriaRole.Link, new() { Name = "Profile page" }).ClickAsync();
 
         await page.GetByText("Welcome to your profile page").ClickAsync();
 
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Privacy policy" }).ClickAsync();
+        await page.GetByRole(AriaRole.Heading, new() { Name = "Following" }).ClickAsync();
+
+        await page.GetByRole(AriaRole.Heading, new() { Name = "Privacy Policy" }).ClickAsync();
 
         await page.GetByRole(AriaRole.Heading, new() { Name = "Authentication Type:" }).ClickAsync();
 
-        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/");
+        await page.GetByRole(AriaRole.Heading, new() { Name = "Claims:" }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Link, new() { Name = "Icon1Chirp!" }).ClickAsync();
+        await page.GetByText("Deletion of Account When").ClickAsync();
 
-        await page.GetByRole(AriaRole.Link, new() { Name = "logout ["+username+"]" }).ClickAsync();
-
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Signed out" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "logout" }).ClickAsync();
 
         await page.GetByText("You have successfully signed").ClickAsync();
 
-        await page.GetByRole(AriaRole.Link, new() { Name = "Icon1Chirp!" }).ClickAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
 
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Public Timeline" }).ClickAsync();
+        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/Helge");
+
+        await page.GetByText("Hello, BDSA students!").ClickAsync();
+
+        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/Rasmus");
+
+        await page.GetByText("Hej, velkommen til kurset.").ClickAsync();
+
+        await page.GotoAsync("https://bdsagroup4chirprazor.azurewebsites.net/Jacqualine%20Gilcoine");
+
+        await page.GetByText("Starbuck now is what we hear").ClickAsync();
+
+        await page.GetByRole(AriaRole.Link, new() { Name = "public timeline" }).ClickAsync();
+
+        await page.Locator("p").Filter(new() { HasText = "Jacqualine Gilcoine Starbuck" }).GetByRole(AriaRole.Link).ClickAsync();
 
     }
 }

--- a/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
+++ b/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
@@ -10,7 +10,7 @@ class Program
     /* RUN THIS LINE TO INSTALL 
     pwsh bin/Debug/net7.0/playwright.ps1 install 
     The playwrighttest tries to access features that are only available to authenticated users
-    for now the developer has to manually login when running the test. Simply run dotnet run, and
+    for now the developer has to manually login when running the test. Simply run dotnet test, and
     a private firefox window will open and playwright will direct the developer to login wherein you
     enter your credentials and the test will run as normal. your credentials are NOT SAVED anywhere
    */

--- a/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
+++ b/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
@@ -87,5 +87,13 @@ class Program
 
         await page.Locator("p").Filter(new() { HasText = "Jacqualine Gilcoine Starbuck" }).GetByRole(AriaRole.Link).ClickAsync();
 
+        await page.GetByRole(AriaRole.Button, new() { Name = "12", Exact = true }).ClickAsync();
+
+        await page.GetByText("Upon making known our desires").ClickAsync();
+
+        await page.GetByRole(AriaRole.Button, new() { Name = "1", Exact = true }).ClickAsync();
+
+        await page.Locator("p").Filter(new() { HasText = "Jacqualine Gilcoine Starbuck" }).GetByRole(AriaRole.Link).ClickAsync();
+
     }
 }

--- a/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
+++ b/test/Chirp.Playwright.Tests/PlaywrightTests/PlaywrightTests.cs
@@ -11,7 +11,7 @@ class Program
     pwsh bin/Debug/net7.0/playwright.ps1 install 
     The playwrighttest tries to access features that are only available to authenticated users
     for now the developer has to manually login when running the test. Simply run dotnet test, and
-    a private firefox window will open and playwright will direct the developer to login wherein you
+    a private chromium window will open and playwright will direct the developer to login wherein you
     enter your credentials and the test will run as normal. your credentials are NOT SAVED anywhere
    */
 


### PR DESCRIPTION
Usertimeline wouldn't show the correct number of pages because of the new combinedauthorfollower implementation so added logic that if looking at a userpage that isn't the same on as the logged in user it simply gets the amount cheeps like it did before the change. Also updated playwright test so that the user doens't have to enter a username variable and "only" run the test and login. The testing is also resistent to any changes that might appear on the website in the future. e.g not testing that cheeps on page 2 are the same as they were when the test were created as that could change